### PR TITLE
Fix README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ It is pretty easy to use: ::
     client = Client('client_id', 'api_key')
     regions = client.regions()
     for region in regions:
-        print region
+        print region.to_json()
 
 
 


### PR DESCRIPTION
The README example currently omits the to_json() call in the regions, printing the object instead of a nice representation. This just adds the calls to be like the example in **init**.py.
