### PR TITLE
Update droplet destroy method from POST to GET

### DIFF
--- a/dop/client.py
+++ b/dop/client.py
@@ -264,7 +264,7 @@ class Client(object):
 
     def destroy_droplet(self, id):
         params = {}
-        json = self.request('/droplets/%s/destroy' % (id), method='POST',
+        json = self.request('/droplets/%s/destroy' % (id), method='GET',
             params=params)
         return json.get('event_id', None)
 


### PR DESCRIPTION
Hi Antonio, I've made an update of the destroy method in order to be aligned with the DO rest api. They changed the Destroy Droplet method from a POST to a GET.

Thanks!
