### PR TITLE
add full response to error message

### DIFF
--- a/dop/client.py
+++ b/dop/client.py
@@ -370,7 +370,8 @@ class Client(object):
             else:
                 raise DOPException('Empty json!')
         else:
-            error = 'Status code: %d' % (response.status_code)
+            error = ('Status code: %d, full response: %s' % 
+                    (response.status_code, response.json()))
             raise DOPException(error)
         return json
 


### PR DESCRIPTION
I started using your module and got first error - and it was hard to find it without full response from server. Actual meaning of 404 was missing argument to /droplets/new, hope it helps somebody else.
