### PR TITLE
Added scrub_data parameter to destroy_droplet method

### DIFF
--- a/dop/client.py
+++ b/dop/client.py
@@ -265,8 +265,12 @@ class Client(object):
             method='POST', params=params)
         return json.get('event_id', None)
 
-    def destroy_droplet(self, id):
+    def destroy_droplet(self, id, scrub_data=False):
         params = {}
+
+        if scrub_data:
+            params['scrub_data'] = True
+
         json = self.request('/droplets/%s/destroy' % (id), method='GET',
             params=params)
         return json.get('event_id', None)


### PR DESCRIPTION
From the Fog Project with the same issue:

> Major security issue: the Digital Ocean API has a parameter on the destroy call to securely scrub the root blockdev on VM destroy, preventing future customers from reading the data left on disk by your VM.
> 
> This is surely a digitalocean security issue, but they're passing it on to users by making it a parameter - rather shitty of them. This is documented in their API at https://cloud.digitalocean.com/api_access - see "scrub_data".
> 
> Fog does not pass this parameter, leaving Fog-destroyed VMs vulnerable to later customers stealing the data contained on them.

Dop has the same issue with not passing scrub_data to the API on destroy_droplet calls.  Fix incoming.
