### PR TITLE
Implement droplets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ python_tempodb.egg-info/
 *.pyc
 *.egg-info/
 .DS_Store
+.idea/

--- a/dop/__init__.py
+++ b/dop/__init__.py
@@ -18,7 +18,9 @@ Basic usage:
 
 """
 
+from pkg_resources import get_distribution
+
 __title__ = 'dop'
-__version__ = '1.6.b1'
+__version__ = get_distribution('dop').version
 __author__ = 'Antonio H Montero'
 __license__ = 'MIT'

--- a/dop/client.py
+++ b/dop/client.py
@@ -11,8 +11,7 @@ This module implements the Digital Ocean API.
 """
 
 import requests
-
-import __version__
+from pkg_resources import get_distribution
 
 API_HOST = 'api.digitalocean.com'
 API_PORT = 80
@@ -219,6 +218,20 @@ class Client(object):
         self.host = host
         self.port = port
         self.secure = secure
+
+    def droplets(self):
+        """
+        This method returns the list of droplets
+        """
+        json = self.request('/droplets/', method='GET')
+        status = json.get('status')
+        if status == 'OK':
+            droplet_json = json.get('droplets', [])
+            droplets = [Droplet.from_json(droplet) for droplet in droplet_json]
+            return droplets
+        else:
+            message = json.get('message', None)
+            raise DOPException('[%s]: %s' % (status, message))
 
     def create_droplet(self, name=None, size=None, image=None, region=None,
                        ssh_key_ids=None, virtio=False, private_networking=False,
@@ -1068,7 +1081,7 @@ class Client(object):
             "Only 'GET' or 'POST' are allowed."
 
         headers = {
-            'User-Agent': 'dop/client v.%s' % __version__
+            'User-Agent': 'dop/client v.%s' % get_distribution("dop").version
         }
 
         params['client_id'] = self.client_id

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name='dop',
-    version=dop.__version__,
+    version='1.6.b2',
     description="A Python client for the Digital Ocean API",
     long_description=open('README.rst').read() + '\n\n' +
                      open('CHANGES.txt').read(),


### PR DESCRIPTION
I added the Client.droplets function which returns a list of Droplet objects.

Additionally I modified the method of the `_version__` local variable. The `from drop.client import Client` threw an error when installed from source using `python setup.py install`. I think it's a better approach.

The error was:

``` bash
(venv)☁  ~  python
Python 2.6.8 (unknown, Aug 25 2013, 00:04:29)
[GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.0.68)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from dop.client import Client
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/apapai/venv/lib/python2.6/site-packages/dop-1.6.b2-py2.6.egg/dop/client.py", line 15, in <module>
    import __version__
ImportError: No module named __version__
```
